### PR TITLE
Add option to export results in csv format for ownership command

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,22 +155,32 @@ ownership/analyser_test.go:104 - 108
 ```sh
 gitwho ownership --help
 Usage of ownership:
+  -authors string
+        Regex for selecting which authors to include in analysis (default ".*")
+  -authors-not string
+        Regex for filtering out authors from analysis
   -branch string
         Branch name to analyse (default "main")
+  -cache-file string
+        If defined, stores results in a cache file that can be used in subsequent calls that uses the same parameters.
+  -cache-ttl int
+        Time in seconds for old items in cache file to be deleted. Defaults to 2 months (default 5184000)
   -files string
         Regex for selecting which file paths to include in analysis (default ".*")
   -files-not string
         Regex for filtering out files from analysis
   -format string
-        Output format. 'full' (duplicated lines and line age details) or 'short' (lines per author) (default "full")
+        Output format. 'full' (more details), 'short' (lines per author), 'graph' (open browser), or 'csv' (CSV format) (default "full")
+  -min-dup-lines int
+        Min number of similar lines in a row to be considered a duplicate (default 4)
   -profile-file string
         Profile file to dump golang runtime data to
   -repo string
         Repository path to analyse (default ".")
   -verbose
-        Show verbose logs during processing (default true)
+        Show verbose logs during processing
   -when string
-        Date time to analyse (default "now")
+        Date to do analysis in repo (default "now")
 ```
 
 ### gitwho changes

--- a/cli/common.go
+++ b/cli/common.go
@@ -19,7 +19,7 @@ type CliOpts struct {
 }
 
 func SetupBasic(cliOpts CliOpts) chan<- utils.ProgressInfo {
-	if cliOpts.Format != "full" && cliOpts.Format != "short" && cliOpts.Format != "graph" {
+	if cliOpts.Format != "full" && cliOpts.Format != "short" && cliOpts.Format != "graph" && cliOpts.Format != "csv" {
 		fmt.Println("'--format' should be (full|short|graph)")
 		os.Exit(1)
 	}

--- a/cli/ownership/formatter_test.go
+++ b/cli/ownership/formatter_test.go
@@ -27,7 +27,7 @@ func TestFormatCodeOwnershipShort(t *testing.T) {
 
 	out, err := FormatCodeOwnershipResults(results, false)
 	require.Nil(t, err)
-	require.Contains(t, out, "Total authors: 3\nTotal files: 2\nTotal lines: 7")
+	require.Contains(t, out, "\nTotal authors: 3\nTotal files: 2\nAuthor clusters:\n")
 }
 
 func TestFormatCodeOwnershipFull(t *testing.T) {

--- a/cli/ownership/formatter_test.go
+++ b/cli/ownership/formatter_test.go
@@ -72,3 +72,29 @@ func TestFormatDuplicatesFull(t *testing.T) {
 	out := FormatDuplicatesResults(results, true)
 	require.Contains(t, out, "Duplicated lines: 0 (0%)\n")
 }
+
+func TestFormatCodeOwnershipResultsCSV(t *testing.T) {
+	repoDir, err := utils.ResolveTestOwnershipRepo()
+	require.Nil(t, err)
+
+	commit, err := utils.ExecGetLastestCommit(repoDir, "main", "", "now")
+	require.Nil(t, err)
+
+	results, err := ownership.AnalyseOwnership(ownership.OwnershipOptions{
+		BaseOptions: utils.BaseOptions{
+			RepoDir: repoDir,
+			Branch:  "main",
+		},
+		MinDuplicateLines: 2,
+		CommitId:          commit.CommitId,
+	}, nil)
+	require.Nil(t, err)
+
+	csvData, err := FormatCodeOwnershipResultsCSV(results)
+	require.Nil(t, err)
+
+	require.Contains(t, csvData, "AuthorName;AuthorMail;OwnedLinesTotal;OwnedLinesAgeDaysSum;OwnedLinesDuplicate;OwnedLinesDuplicateOriginal;OwnedLinesDuplicateOriginalOthers")
+	require.Contains(t, csvData, "author3;<author3@mail.com>;5;0.00;0;0;0")
+	require.Contains(t, csvData, "author2;<author2@mail.com>;1;0.00;0;0;0")
+	require.Contains(t, csvData, "author1;<author1@mail.com>;1;0.00;0;0;0")
+}

--- a/cli/ownership/ownership.go
+++ b/cli/ownership/ownership.go
@@ -26,7 +26,7 @@ func RunOwnership(osArgs []string) {
 	flags.IntVar(&opts.CacheTTLSeconds, "cache-ttl", 5184000, "Time in seconds for old items in cache file to be deleted. Defaults to 2 months")
 	flags.IntVar(&opts.MinDuplicateLines, "min-dup-lines", 4, "Min number of similar lines in a row to be considered a duplicate")
 	flags.StringVar(&when, "when", "now", "Date to do analysis in repo")
-	flags.StringVar(&cliOpts.Format, "format", "full", "Output format. 'full' (more details), 'short' (lines per author) or 'graph' (open browser)")
+	flags.StringVar(&cliOpts.Format, "format", "full", "Output format. 'full' (more details), 'short' (lines per author), 'graph' (open browser), or 'csv' (CSV format)")
 	flags.StringVar(&cliOpts.GoProfileFile, "profile-file", "", "Profile file to dump golang runtime data to")
 	flags.BoolVar(&cliOpts.Verbose, "verbose", false, "Show verbose logs during processing")
 
@@ -76,5 +76,12 @@ func RunOwnership(osArgs []string) {
 		}
 		fmt.Printf("\nServing graph at %s\n", url)
 		select {}
+
+	case "csv":
+		output, err := FormatCodeOwnershipResultsCSV(ownershipResult)
+		if err != nil {
+			fmt.Printf("Couldn't format results as CSV. err=%s", err)
+		}
+		fmt.Println(output)
 	}
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request -->
<!-- For more information, see the `CONTRIBUTING` guide. -->

## Why?

This PR introduces CSV output format support to the `ownership` command, allowing users to request structured data for automation and analysis.

## What?

The key changes in this PR include:

- Added a 'format' option to the "ownership" command for CSV output.
- Implemented the `FormatCodeOwnershipResultsCSV` function.
- Updated the README with 'csv' format documentation.
- Added unit tests for the new functionality.

## Review instructions

For the review process, please consider the following:

 - The 'format' option and `FormatCodeOwnershipResultsCSV` function.
 - The README update for 'csv' format.
 - The new unit tests to validate the functionality.

## Related

Fixes #16 
